### PR TITLE
Changes for snapshots to work in regions other than us-east-1

### DIFF
--- a/chef/cookbooks/mongodb/definitions/mongodb.rb
+++ b/chef/cookbooks/mongodb/definitions/mongodb.rb
@@ -250,6 +250,7 @@ define :create_raided_drives_from_snapshot, :disk_counts => 4,
         action     [:auto_attach]
         snapshots  MongoDB.find_snapshots(aws["aws_access_key_id"],
                                           aws["aws_secret_access_key"],
+                                          node[:backups][:region],
                                           node[:backups][:mongo_volumes],
                                           node[:mongodb][:cluster_name])
   end

--- a/chef/cookbooks/mongodb/libraries/ec2.rb
+++ b/chef/cookbooks/mongodb/libraries/ec2.rb
@@ -7,7 +7,7 @@ class Chef::ResourceDefinitionList::MongoDB
   # nil.  The returned snapshots array will be parallel to the volumes array,
   # i.e the latest snapshot for the Nth volume in the array will be the Nth
   # snapshot in the result.
-  def self.find_snapshots(key, secret_key, volumes, clustername)
+  def self.find_snapshots(key, secret_key, region, volumes, clustername)
     require 'aws-sdk'
 
     if volumes.size == 0
@@ -18,7 +18,7 @@ class Chef::ResourceDefinitionList::MongoDB
     # Compute the latest snapshots.
     ec2 = AWS::EC2.new(
           :access_key_id => key,
-          :secret_access_key => secret_key)
+          :secret_access_key => secret_key).regions[region]
 
     # This is an array of arrays.  snapshots[i] will have the sorted list of
     # snapshots for volumes[i].  The snapshots are sorted by description which

--- a/chef/cookbooks/mongodb/libraries/mongodb.rb
+++ b/chef/cookbooks/mongodb/libraries/mongodb.rb
@@ -29,12 +29,8 @@ class Chef::ResourceDefinitionList::MongoDB
     require 'mongo'
 
     if members.length == 0
-      if Chef::Config[:solo]
-        abort("Cannot configure replicaset '#{name}', no member nodes found")
-      else
-        Chef::Log.warn("Cannot configure replicaset '#{name}', no member nodes found")
-        return
-      end
+			Chef::Log.warn("Cannot configure replicaset '#{name}', no member nodes found")
+			return
     end
 
     begin

--- a/chef/cookbooks/mongodb/templates/default/raid_snapshot.sh.erb
+++ b/chef/cookbooks/mongodb/templates/default/raid_snapshot.sh.erb
@@ -21,5 +21,5 @@ else
   string="Mongo RAID Snapshot $(date +%F:%T)"
 fi
 
-/usr/local/bin/mongo-ec2-raid-snapshot --quiet --region us-east-1 --description "$string" <%= node['backups']['mongo_volumes'].join(" ") %>
+/usr/local/bin/mongo-ec2-raid-snapshot --quiet --region <%= node['backups']['region'] %> --description "$string" <%= node['backups']['mongo_volumes'].join(" ") %>
 


### PR DESCRIPTION
Simple stuff.  Also, I'm not using chef to reconfigure the replica set (not ready for that level of automation yet :) and had to change the error -> warning for chef solo (not sure why this was an error for solo but only warning for chef-server)

Thanks!  I'm loving restoring from backups with a simple chef provision.  
